### PR TITLE
Update nes css

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% seo %}
-  <link rel="stylesheet" href="https://unpkg.com/nes.css@2.2.0/css/nes.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/nes.css@2.3.0/css/nes.min.css" />
   <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
   <!--[if lt IE 9]>
   <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>

--- a/jekyll-theme-8bit.gemspec
+++ b/jekyll-theme-8bit.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name     = 'jekyll-theme-8bit'
-  spec.version  = '0.4.0'
+  spec.version  = '0.5.0'
   spec.authors  = ['Juliano Fernandes']
   spec.email    = ['julianofernandes@gmail.com']
   spec.summary  = 'A Jekyll theme inspired by classic 8bit games.'


### PR DESCRIPTION
Hi 
This PR is linked to the [ISSUE-12](urlhttps://github.com/julianolf/jekyll-theme-8bit/issues/12.
Update nes css version from 2.2.0 to 2.3.0.
I hope it's all good.
Tks
Leandro.